### PR TITLE
Fix BloomFilter serialization

### DIFF
--- a/src/orestes/bloomfilter/CBloomFilter.java
+++ b/src/orestes/bloomfilter/CBloomFilter.java
@@ -99,7 +99,7 @@ public class CBloomFilter<T> extends BloomFilter<T> {
 	 *            object to be deleted
 	 */
 	public void remove(T value) {
-		remove(value.toString().getBytes(defaultCharset));
+		remove(value.toString().getBytes(getDefaultCharset()));
 	}
 
 	/**

--- a/src/orestes/bloomfilter/redis/BloomFilterRedis.java
+++ b/src/orestes/bloomfilter/redis/BloomFilterRedis.java
@@ -76,7 +76,7 @@ public class BloomFilterRedis<T> extends BloomFilter<T> {
 	public void addAll(Collection<T> values) {
 		begin();
 		for (T val : values) {
-			super.add(val.toString().getBytes(defaultCharset));
+			super.add(val.toString().getBytes(getDefaultCharset()));
 		}
 		if (commit() == null)
 			addAll(values);

--- a/src/orestes/bloomfilter/redis/CBloomFilterRedis.java
+++ b/src/orestes/bloomfilter/redis/CBloomFilterRedis.java
@@ -143,7 +143,7 @@ public class CBloomFilterRedis<T> extends CBloomFilter<T> {
 	public void addAll(Collection<T> values) {
 		begin();
 		for (T val : values) {
-			super.add(val.toString().getBytes(defaultCharset));
+			super.add(val.toString().getBytes(getDefaultCharset()));
 		}
 		if (commit() == null)
 			addAll(values);

--- a/test/orestes/bloomfilter/test/BFTests.java
+++ b/test/orestes/bloomfilter/test/BFTests.java
@@ -2,6 +2,14 @@ package orestes.bloomfilter.test;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 
 import orestes.bloomfilter.BloomFilter;
@@ -313,5 +321,41 @@ public class BFTests {
 		System.out.println("Total time for " + inserts
 				+ " add operations in both a counting and a normal bloom filter: " + (end - begin) * 1.0 / 1000000000
 				+ " s");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void serializeBloomFilter() throws IOException, ClassNotFoundException {
+            BloomFilter<String> b     = new BloomFilter<String>(1000, 0.02);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            ObjectOutput out          = new ObjectOutputStream(bos);
+
+            b.add("foo");
+            b.add("bar");
+
+            assertTrue(b instanceof Serializable);
+            assertTrue(b.contains("foo"));
+            assertTrue(b.contains("bar"));
+
+            out.writeObject(b);
+
+            byte[] byteArray = bos.toByteArray();
+
+            out.close();
+            bos.close();
+
+            ByteArrayInputStream bis = new ByteArrayInputStream(byteArray);
+            ObjectInput in           = new ObjectInputStream(bis);
+            Object object            = in.readObject();
+
+            bis.close();
+            in.close();
+
+            assertTrue(object instanceof BloomFilter);
+
+            b = (BloomFilter<String>) object;
+
+            assertTrue(b.contains("foo"));
+            assertTrue(b.contains("bar"));
 	}
 }


### PR DESCRIPTION
Hi

This patch fix a `NotSerializableException` dispatched by `readObject` while it try to serialize `MessageDigest` and `Charset`..
