### PR TITLE
Added support for SSL configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 dependencies {
     compile(
             'com.google.code.gson:gson:2.5',
-            'redis.clients:jedis:2.8.0',
+            'redis.clients:jedis:2.9.0',
             //'org.apache.commons:commons-pool2:2.2',
             'org.slf4j:slf4j-api:1.7.12'
     )

--- a/src/main/java/orestes/bloomfilter/FilterBuilder.java
+++ b/src/main/java/orestes/bloomfilter/FilterBuilder.java
@@ -29,6 +29,7 @@ public class FilterBuilder implements Cloneable, Serializable {
     private String redisHost = "localhost";
     private Integer redisPort = 6379;
     private Integer redisConnections = 10;
+    private boolean redisSsl = false;
     private HashMethod hashMethod = HashMethod.Murmur3KirschMitzenmacher;
     private HashFunction hashFunction = HashMethod.Murmur3KirschMitzenmacher.getHashFunction();
     private Set<Entry<String, Integer>> slaves = new HashSet<>();
@@ -159,6 +160,7 @@ public class FilterBuilder implements Cloneable, Serializable {
         this.redisHost(pool.getHost());
         this.redisPort(pool.getPort());
         this.redisConnections(pool.getRedisConnections());
+        this.redisSsl(pool.getSsl());
         this.pool = pool;
         return this;
     }
@@ -208,6 +210,18 @@ public class FilterBuilder implements Cloneable, Serializable {
     public FilterBuilder redisConnections(int numConnections) {
         this.redisBacked = true;
         this.redisConnections = numConnections;
+        return this;
+    }
+
+    /**
+     * Enables or disables SSL connection to Redis. <p><b>Default</b>: false</p>
+     *
+     * @param ssl enables or disables SSL connection to Redis
+     * @return the modified FilterBuilder (fluent interface)
+     */
+    public FilterBuilder redisSsl(boolean ssl) {
+        this.redisBacked = true;
+        this.redisSsl = ssl;
         return this;
     }
 
@@ -414,6 +428,13 @@ public class FilterBuilder implements Cloneable, Serializable {
     }
 
     /**
+     * @return if SSL is enabled for Redis connection
+     */
+    public boolean redisSsl() {
+        return redisSsl;
+    }
+
+    /**
      * @return The hash method to be used by the Bloom filter
      */
     public HashMethod hashMethod() {
@@ -516,7 +537,7 @@ public class FilterBuilder implements Cloneable, Serializable {
     public RedisPool pool() {
         if(done && pool == null) {
             pool = new RedisPool(redisHost(), redisPort(), redisConnections(),
-                getReadSlaves(), password());
+                getReadSlaves(), password(), redisSsl());
         }
         return pool;
     }

--- a/src/test/java/orestes/bloomfilter/test/helper/Helper.java
+++ b/src/test/java/orestes/bloomfilter/test/helper/Helper.java
@@ -21,7 +21,7 @@ public class Helper {
     }
 
     public static RedisPool getPool() {
-        return new RedisPool(host, port, connections, null);
+        return new RedisPool(host, port, connections, null, false);
     }
 
     public static <T> BloomFilterMemory<T> createFilter(int m, int k, HashMethod hm) {

--- a/src/test/java/orestes/bloomfilter/test/tutorial/Tutorial.java
+++ b/src/test/java/orestes/bloomfilter/test/tutorial/Tutorial.java
@@ -32,7 +32,7 @@ public class Tutorial {
 
     public static void redisBenchmark() {
         int connections = 100;
-        RedisPool pool = new RedisPool("localhost", 6379, connections);
+        RedisPool pool = new RedisPool("localhost", 6379, connections, false);
         ExecutorService exec = Executors.newFixedThreadPool(connections);
 
         int rounds = 200_000;


### PR DESCRIPTION
Jedis 2.9.0 added support for SSL. This PR updates the version of Jedis along with adding support for configuring SSL with `FilterBuilder`. `RedisPool#createJedisPool` now creates a `JedisPool` with this configuration (which defaults to `false`).