### PR TITLE
Addressing 'NumberFormatException: Null' in CountingBloomFilterRedis …

### DIFF
--- a/src/main/java/orestes/bloomfilter/redis/CountingBloomFilterRedis.java
+++ b/src/main/java/orestes/bloomfilter/redis/CountingBloomFilterRedis.java
@@ -114,7 +114,7 @@ public class CountingBloomFilterRedis<T> implements CountingBloomFilter<T> {
         return pool.allowingSlaves().safelyReturn(jedis -> {
             String[] hashesString = encode(hash(toBytes(element)));
             List<String> hmget = jedis.hmget(keys.COUNTS_KEY, hashesString);
-            return hmget.stream().map(Long::valueOf).min(Comparator.<Long>naturalOrder()).get();
+            return hmget.stream().filter(Objects::nonNull).map(Long::valueOf).min(Comparator.<Long>naturalOrder()).get();
         });
     }
 

--- a/src/main/java/orestes/bloomfilter/redis/CountingBloomFilterRedis.java
+++ b/src/main/java/orestes/bloomfilter/redis/CountingBloomFilterRedis.java
@@ -114,8 +114,8 @@ public class CountingBloomFilterRedis<T> implements CountingBloomFilter<T> {
         return pool.allowingSlaves().safelyReturn(jedis -> {
             String[] hashesString = encode(hash(toBytes(element)));
             List<String> hmget = jedis.hmget(keys.COUNTS_KEY, hashesString);
-            return hmget.stream().filter(Objects::nonNull).map(Long::valueOf).min(Comparator.<Long>naturalOrder()).orElse(0L);
-        });
+            return hmget.stream().map(i -> (i != null) ? Long.valueOf(i) : 0L).min(Comparator.<Long> naturalOrder()).get();
+          });
     }
 
 

--- a/src/main/java/orestes/bloomfilter/redis/CountingBloomFilterRedis.java
+++ b/src/main/java/orestes/bloomfilter/redis/CountingBloomFilterRedis.java
@@ -114,7 +114,7 @@ public class CountingBloomFilterRedis<T> implements CountingBloomFilter<T> {
         return pool.allowingSlaves().safelyReturn(jedis -> {
             String[] hashesString = encode(hash(toBytes(element)));
             List<String> hmget = jedis.hmget(keys.COUNTS_KEY, hashesString);
-            return hmget.stream().filter(Objects::nonNull).map(Long::valueOf).min(Comparator.<Long>naturalOrder()).get();
+            return hmget.stream().filter(Objects::nonNull).map(Long::valueOf).min(Comparator.<Long>naturalOrder()).orElse(0L);
         });
     }
 


### PR DESCRIPTION
…stated in Issue 40


Adding a nonNull filter to "getEstimatedCount". I'm not 100% sure whether nulls should be ignored or converted to 0 but I believe ignoring them is the correct path.