### PR TITLE
Allow customization via inheritance of redis pool

### DIFF
--- a/src/main/java/orestes/bloomfilter/redis/helper/RedisPool.java
+++ b/src/main/java/orestes/bloomfilter/redis/helper/RedisPool.java
@@ -55,7 +55,7 @@ public class RedisPool {
         return pool;
     }
 
-    private JedisPool createJedisPool(String host, int port, int redisConnections, String password, boolean ssl) {
+    protected JedisPool createJedisPool(String host, int port, int redisConnections, String password, boolean ssl) {
         JedisPoolConfig config = new JedisPoolConfig();
         config.setBlockWhenExhausted(true);
         config.setMaxTotal(redisConnections);


### PR DESCRIPTION
Right now there is no way to create or modify a custom instance of JedisPool inside the RedisPool class.

I have modified the visibility of the `createJedisPool()` method, in order to allow customizations to the wrapped object via inheritance.