### PR TITLE
JCenter requires https now, depedency won’t resolve with http

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ too):
        </snapshots>
        <id>central</id>
        <name>bintray</name>
-       <url>http://jcenter.bintray.com</url>
+       <url>https://jcenter.bintray.com</url>
    </repository>
 </repositories>
 ```


### PR DESCRIPTION
Simple fix for README.